### PR TITLE
Add deploy script for GKE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ build:
 
 push:
 	docker/push.sh
+
+deploy:
+	k8s/deploy.sh

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo "Installing gcloud..."
+export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo apt-get update && sudo apt-get install -y google-cloud-sdk kubectl
+
+echo "Setting up gcloud..."
+gcloud auth activate-service-account $SERVICE_ACCOUNT_NAME --key-file service_account.json
+gcloud config set project semaphore-stg
+
+echo "Setting up kubectl..."
+gcloud container clusters get-credentials $CLUSTER_NAME --zone $CLUSTER_ZONE
+
+echo "Deploying to cluster..."
+kubectl apply -f deploy.yml --validate=false
+kubectl describe deployment hubot


### PR DESCRIPTION
We want to automate deploy on GKE. This script should do the work.

In this regard we need to setup following stuff on Semaphore:
```
# Environment variables
$SERVICE_ACCOUNT_NAME
$CLUSTER_NAME
$CLUSTER_ZONE

# Configuration file 
# Semaphore shared configuration is recommended
# note that you can setup shared configuration only if you have admin privileges

service_account.json
```